### PR TITLE
Links to Telegram to use `tg://` protocol

### DIFF
--- a/client/components/Footer/Footer.tsx
+++ b/client/components/Footer/Footer.tsx
@@ -82,7 +82,7 @@ const Footer: React.SFC = () => (
           <Separator>|</Separator>
         </ListItem>
         <ListItem>
-          <a href="https://t.me/tgdr_io" title="Telegram">
+          <a href="tg://resolve?domain=tgdr_io" title="Telegram">
             <Icon
               size={14}
               name="telegram"

--- a/client/utils/utils.ts
+++ b/client/utils/utils.ts
@@ -33,7 +33,7 @@ export const getOpenLink = (username: string) => (
   e: React.MouseEvent<HTMLElement>
 ) => {
   e.stopPropagation();
-  window.open(`https://t.me/${username}`, '_blank');
+  window.open(`tg://resolve?domain=${username}`, '_blank');
   window.focus();
 };
 


### PR DESCRIPTION
1) It's unnecessary to redirect to t.me, and then have a secondary redirect to Telegram.
2) For countries where Telegram websites are blocked, but the app isn't, or the user uses Telegram's builtin proxies, it's a hassle to either also proxy the browser, or to copy the username manually and paste it in Telegram. 

Either way it's a few wasted moments. I suggest using `tg://` protocol directly (the redirected page does this anyway).